### PR TITLE
Load custom adapters

### DIFF
--- a/Controller/MembershipController.php
+++ b/Controller/MembershipController.php
@@ -232,7 +232,6 @@ class MembershipController extends Controller
                     }
                 }
 
-                //return $this->setDataTemplateVariables($user, $errors, $messages, $dataTpl);
                 return $this->redirect($this->generateUrl('newscoop_paywall_membership_getsubscriptions'));
             } else {
                 $data = $form->getData();

--- a/Controller/UsersSubscriptionsController.php
+++ b/Controller/UsersSubscriptionsController.php
@@ -37,7 +37,6 @@ class UsersSubscriptionsController extends Controller
      */
     public function loadSubscriptionsAction(Request $request)
     {
-        $cacheService = $this->get('newscoop.cache');
         $subscriptionService = $this->get('subscription.service');
         $criteria = $this->processRequest($request);
         $userSubscriptions = $this->get('subscription.service')->getListByCriteria($criteria);

--- a/EventListener/LifecycleSubscriber.php
+++ b/EventListener/LifecycleSubscriber.php
@@ -11,6 +11,8 @@ namespace Newscoop\PaywallBundle\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Newscoop\EventDispatcher\Events\GenericEvent;
 use Newscoop\PaywallBundle\Entity\Settings;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Event lifecycle management
@@ -29,11 +31,9 @@ class LifecycleSubscriber implements EventSubscriberInterface
         $tool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
         $tool->updateSchema($this->getClasses(), true);
 
-        $adapter = new Settings();
-        $adapter->setName('Paypal');
-        $adapter->setValue('PaypalAdapter');
-        $this->em->persist($adapter);
-        $this->em->flush();
+        //install custom adapters located in other plugins (dir: Adapter/PaywallAdapters)
+        $this->installCustomAdapters();
+        $this->installAdapters();
 
         // Generate proxies for entities
         $this->em->getProxyFactory()->generateProxyClasses($this->getClasses(), __DIR__ . '/../../../../library/Proxy');
@@ -44,6 +44,9 @@ class LifecycleSubscriber implements EventSubscriberInterface
         $tool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
         $tool->updateSchema($this->getClasses(), true);
 
+        $this->installCustomAdapters();
+        $this->installAdapters();
+
         // Generate proxies for entities
         $this->em->getProxyFactory()->generateProxyClasses($this->getClasses(), __DIR__ . '/../../../../library/Proxy');
     }
@@ -52,6 +55,77 @@ class LifecycleSubscriber implements EventSubscriberInterface
     {
         $tool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
         $tool->dropSchema($this->getClasses(), true);
+    }
+
+    /**
+     * Install (copy) custom adapters
+     * @return void
+     * @throws Exception
+     */
+    private function installCustomAdapters()
+    {
+        $fs = new Filesystem();
+        $finder = new Finder();
+        $pluginsDir = __DIR__ . '/../../../../';
+
+        $iterator = $finder
+            ->ignoreUnreadableDirs()
+            ->files()
+            ->name('*Adapter.zip')
+            ->in($pluginsDir . '*/*/Adapter/PaywallAdapters/');
+
+        foreach ($iterator as $file) {
+            $zip = new \ZipArchive();
+            try {
+                if ($zip->open($file->getRealpath()) === true) {
+                    for ($i = 0; $i < $zip->numFiles; $i++) {
+                        $zip->extractTo(__DIR__ . '/../Adapter/', array($zip->getNameIndex($i)));
+                    }
+
+                    $zip->close();
+                }
+            } catch (\Exception $e) {
+                throw new \Exception('Error extracting zip with adapter!');
+            }
+        }
+    }
+
+    /**
+     * Install all adapters
+     * @return void
+     * @throws Exception
+     */
+    private function installAdapters()
+    {
+        $fs = new Filesystem();
+        $finder = new Finder();
+
+        try {
+            $iterator = $finder
+                ->files()
+                ->name('*Adapter.php')
+                ->in(__DIR__  . '/../Adapter/');
+
+            foreach ($iterator as $file) {
+                $oneAdapter = $this->em->getRepository('Newscoop\PaywallBundle\Entity\Settings')
+                    ->findOneBy(array('value' => substr($file->getFilename(), 0, -4)));
+
+                if (!$oneAdapter) {
+                    $adapter = new Settings();
+                    $adapter->setName(str_replace("Adapter.php", "", $file->getFilename()));
+                    $adapter->setValue(substr($file->getFilename(), 0, -4));
+                    if (substr($file->getFilename(), 0, -4) !== 'PaypalAdapter') {
+                        $adapter->setIsActive(false);
+                    }
+
+                    $this->em->persist($adapter);
+                }
+            }
+
+            $this->em->flush();
+        } catch (\Exception $e) {
+            throw new \Exception('Error installing adapters!');
+        }
     }
 
     public static function getSubscribedEvents()

--- a/Services/MembershipService.php
+++ b/Services/MembershipService.php
@@ -114,7 +114,7 @@ class MembershipService
         $smarty->assign('userLink', $request->getUriForPath($this->zendRouter->assemble(array('controller' => 'user', 'action' => 'profile')) . '/' . $user->getUsername()));
         if ($toUser) {
             $message = $this->templatesService->fetchTemplate("email_membership_user.tpl");
-            $this->emailService->send($this->placeholdersService->get('subject'), $message, array($user->getEmail()));
+            $this->emailService->send($this->placeholdersService->get('subject'), $message, array($user->getEmail()), array($this->preferencesService->PaywallMembershipNotifyEmail));
         }
 
         $message = $this->templatesService->fetchTemplate("email_membership_staff.tpl");


### PR DESCRIPTION
Paywall can isntall custom Adapters from now on. These adapters can be placed in any plugin but under the specified directory: `plugins/ExamplePluginBundle/Adapter/PaywallAdapter/`.

Adapter should have `Adapter` text at the end of adapter name, e.g. `MembershipAdapter.php`.

Every adapter needs to be archived.
In this example `MembershipAdapter.php` must be archived to `MembershipAdapter.zip` and placed to `plugins/ExamplePluginBundle/Adapter/PaywallAdapter/MembershipAdapter.zip`

Paywall will automatically install it during the installation process or update process.

Default Adapter is `PaypalAdapter` and it will be set by default when Paywall plugin will be installed.
